### PR TITLE
Fix: add background classes for darkmode

### DIFF
--- a/src/code.css
+++ b/src/code.css
@@ -142,3 +142,10 @@ pre[class*='language-'] ::selection {
   padding: 0.15em 0.2em 0.05em;
   white-space: normal;
 }
+
+@media (prefers-color-scheme: dark) {
+  :not(pre) > code {
+    background: #222529;
+    color: #e8912d;
+  }
+}

--- a/src/global.css
+++ b/src/global.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+html,
+body {
+  height: 100%;
+  background-color: #111827;
+}
+
 @font-face {
   font-family: 'Menlo';
   src: url(/fonts/Menlo-Regular.woff) format("woff");
@@ -33,4 +39,14 @@
   margin: auto;
   margin-top: 30px !important;
   margin-bottom: 30px !important;
+}
+
+@media (prefers-color-scheme: dark) {
+  .prose p {
+    color: #cbd5e0;
+  }
+
+  .prose li {
+    color: #a0aec0;
+  }
 }

--- a/src/layout.jsx
+++ b/src/layout.jsx
@@ -16,7 +16,7 @@ const Layout = ({ children }) => (
           <div className="sticky top-0 p-4 w-full text-center">
             <div className="">
               <Link to="/">
-                <h1 className="text-2xl">Juraj Majerik</h1>
+                <h1 className="text-2xl dark:text-white">Juraj Majerik</h1>
               </Link>
             </div>
             <StaticImage

--- a/src/pages/blog/{Mdx.frontmatter__slug}.jsx
+++ b/src/pages/blog/{Mdx.frontmatter__slug}.jsx
@@ -15,7 +15,7 @@ const BlogPost = ({ data, children }) => {
       <article className="">
         <h1 className="text-2xl font-medium tracking-normal text-zinc-800 dark:text-zinc-100">{frontmatter.title}</h1>
         <small className="font-light mt-1 z-10 text-sm text-zinc-500 dark:text-zinc-500">{date}</small>
-        <div className="mt-4 prose dark:prose-invert">{children}</div>
+        <div className="mt-4 prose dark">{children}</div>
       </article>
     </Layout>
   );

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -11,7 +11,7 @@ const IndexPage = ({ data }) => (
 
           return (
             <Link key={node.id} to={`blog/${node.frontmatter.slug}`}>
-              <article className="h-125 transition-all hover:drop-shadow-sm m-2 p-4 bg-white rounded-md border border-slate-200 hover:border-slate-300">
+              <article className="h-125 transition-all hover:drop-shadow-sm m-2 p-4 bg-white dark:bg-gray-800 rounded-md border border-slate-200 hover:border-slate-300">
                 <h3 className="text-base font-medium tracking-normal text-zinc-800 dark:text-zinc-100">
                   {node.frontmatter.title}
                 </h3>


### PR DESCRIPTION
In this PR I have fixed tailwinds darkmode behaviour if you have prefer-darkmode enabled.

Before (see the titles of the articles. Basically unreadable on anything else then macbook screen):
<img width="1306" alt="Screenshot 2022-12-02 at 14 08 35" src="https://user-images.githubusercontent.com/17283014/205319113-ed373a59-0258-4640-811d-7a662768e732.png">

After: 
<img width="1328" alt="image" src="https://user-images.githubusercontent.com/17283014/205324217-42df0adb-1860-4030-b3e2-f616b6ad7ec4.png">
<img width="811" alt="image" src="https://user-images.githubusercontent.com/17283014/205324247-c8f3759a-4f05-4966-ae74-584d8a555c2a.png">

This will now correctly render in dark mode if your OS is set up to prefer dark mode with `@media (prefers-color-scheme: dark)` query.