### PR TITLE
Corrected Handler In HandleFunc Function

### DIFF
--- a/blog/6-http-server/index.mdx
+++ b/blog/6-http-server/index.mdx
@@ -19,7 +19,7 @@ func getData(w http.ResponseWriter, req *http.Request) {
 We register our handler by calling ```http.HandleFunc()``` method, passing the path and the handler itself.
 
 ```go
-http.HandleFunc("/data", headers)
+http.HandleFunc("/data", getData)
 ```
 
 Finally, we define a port to listen to:


### PR DESCRIPTION
This PR corrects the http.HandleFunc call from 
- #6: https://jurajmajerik.com/blog/http-server/
- Documentation (http.HandleFunc): https://pkg.go.dev/net/http#HandleFunc

Issue
- 'headers' was passed as the function handler, when your custom function 'getData' should have been passed as the handler

<img width="959" alt="image" src="https://github.com/jurajmajerik/blog/assets/18294827/45e224b8-66db-46e5-83fc-33a15616fb7c">

<img width="961" alt="image" src="https://github.com/jurajmajerik/blog/assets/18294827/64bb96ca-edf2-4fd2-87e9-ce33a4dc7028">

